### PR TITLE
Resolved the issue of user-defined start and stop angles not actually be...

### DIFF
--- a/libs/LMS1xx.cpp
+++ b/libs/LMS1xx.cpp
@@ -80,12 +80,12 @@ void LMS1xx::startMeas() {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+	if (buf[0] != 0x02)
+        std::cout << "invalid packet recieved" << std::endl;
+	if (debug) {
+        buf[len] = 0;
+        std::cout << buf << std::endl;
+	}
 }
 
 void LMS1xx::stopMeas() {
@@ -95,12 +95,12 @@ void LMS1xx::stopMeas() {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+	if (buf[0] != 0x02)
+        std::cout << "invalid packet recieved" << std::endl;
+	if (debug) {
+        buf[len] = 0;
+        std::cout << buf << std::endl;
+	}
 }
 
 status_t LMS1xx::queryStatus() {
@@ -129,12 +129,12 @@ void LMS1xx::login() {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+	if (buf[0] != 0x02)
+        std::cout << "invalid packet recieved" << std::endl;
+	if (debug) {
+        buf[len] = 0;
+        std::cout << buf << std::endl;
+	}
 }
 
 scanCfg LMS1xx::getScanCfg() const {
@@ -145,12 +145,12 @@ scanCfg LMS1xx::getScanCfg() const {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+//	if (buf[0] != 0x02)
+//        std::cout << "invalid packet recieved" << std::endl;
+//	if (debug) {
+//        buf[len] = 0;
+//        std::cout << buf << std::endl;
+//	}
 
 	sscanf(buf + 1, "%*s %*s %X %*d %X %X %X", &cfg.scaningFrequency,
 			&cfg.angleResolution, &cfg.startAngle, &cfg.stopAngle);
@@ -159,6 +159,9 @@ scanCfg LMS1xx::getScanCfg() const {
 
 void LMS1xx::setScanCfg(const scanCfg &cfg) {
 	char buf[100];
+    
+    //Start and stop angle are acutally ignored when using mLMPsetscancfg
+    //and default LMS1xx and LMS5xx ranges are different. 
 	sprintf(buf, "%c%s %X +1 %X %X %X%c", 0x02, "sMN mLMPsetscancfg",
 			cfg.scaningFrequency, cfg.angleResolution, cfg.startAngle,
 			cfg.stopAngle, 0x03);
@@ -166,8 +169,49 @@ void LMS1xx::setScanCfg(const scanCfg &cfg) {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
+    
+//    if (buf[0] != 0x02)
+//        std::cout << "invalid packet recieved" << std::endl;
+//    if (debug) {
+//        buf[len] = 0;
+//        std::cout << buf << std::endl;
+//	}
 
 	buf[len - 1] = 0;
+}
+
+void LMS1xx::setScanRange(const scanCfg &cfg) {
+    char buf[100];
+    
+    //Set start and stop angle
+    sprintf(buf, "%c%s +1 %X %X %X%c", 0x02, "sWN LMPoutputRange",
+			cfg.angleResolution, cfg.startAngle, cfg.stopAngle, 0x03);
+
+	write(sockDesc, buf, strlen(buf));
+
+	int len = read(sockDesc, buf, 100);
+
+}
+
+scanCfg LMS1xx::getScanRange() {
+	scanCfg cfg;
+	char buf[100];
+	sprintf(buf, "%c%s%c", 0x02, "sRN LMPoutputRange", 0x03);
+    
+	write(sockDesc, buf, strlen(buf));
+    
+	int len = read(sockDesc, buf, 100);
+    //	if (buf[0] != 0x02)
+    //        std::cout << "invalid packet recieved" << std::endl;
+    //	if (debug) {
+    //        buf[len] = 0;
+    //        std::cout << buf << std::endl;
+    //	}
+    
+	sscanf(buf + 1, "%*s %*s %*d %X %X %X",
+           &cfg.angleResolution, &cfg.startAngle, &cfg.stopAngle);
+    
+    return cfg;
 }
 
 void LMS1xx::setScanDataCfg(const scanDataCfg &cfg) {
@@ -470,12 +514,12 @@ void LMS1xx::saveConfig() {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+	if (buf[0] != 0x02)
+		std::cout << "invalid packet recieved" << std::endl;
+	if (debug) {
+		buf[len] = 0;
+        std::cout << buf << std::endl;
+	}
 }
 
 void LMS1xx::startDevice() {
@@ -485,10 +529,13 @@ void LMS1xx::startDevice() {
 	write(sockDesc, buf, strlen(buf));
 
 	int len = read(sockDesc, buf, 100);
-	//	if (buf[0] != 0x02)
-	//		std::cout << "invalid packet recieved" << std::endl;
-	//	if (debug) {
-	//		buf[len] = 0;
-	//		std::cout << buf << std::endl;
-	//	}
+    
+	if (buf[0] != 0x02)
+    {
+        std::cout << "invalid packet recieved" << std::endl;
+    }
+	if (debug) {
+        buf[len] = 0;
+		std::cout << buf << std::endl;
+	}
 }

--- a/libs/LMS1xx.h
+++ b/libs/LMS1xx.h
@@ -241,6 +241,7 @@ public:
 
 	/*!
 	* @brief Get current scan configuration.
+    * Important to note: this always returns the default, immutable angle range of the laser. 
 	* Get scan configuration :
 	* - scanning frequency.
 	* - scanning resolution.
@@ -252,14 +253,24 @@ public:
 
 	/*!
 	* @brief Set scan configuration.
-	* Get scan configuration :
-	* - scanning frequency.
-	* - scanning resolution.
-	* - start angle.
-	* - stop angle.
+    * Note that the laser's start and stop angles are immutable. Those cfg values are ignored by
+    * this function. If you wish to shrink your data set to a certain range, use setScanRange.
 	* @param cfg structure containing scan configuration.
 	*/
 	void setScanCfg(const scanCfg &cfg);
+    
+    /*!
+     * @brief Set output range.
+     * This does not stop the laser from physically scanning its full range. Instead it ensures the laser
+     * only sends back data relating to a certain subset of that range. Resolution/freq values ignored.
+     */
+	void setScanRange(const scanCfg &cfg);
+    
+    /*!
+     * @brief Get output range.
+     * Returns the laser's actual output range (as opposed to the actual, immutable angle range it scans). 
+     */
+	scanCfg getScanRange();
 
 	/*!
 	* @brief Set scan data configuration.

--- a/src/ofxSick.cpp
+++ b/src/ofxSick.cpp
@@ -41,9 +41,9 @@ string getStatusString(int status) {
 ofxSick::ofxSick()
 	:angleOffset(0)
 	,scanningFrequency(50)
-	,startAngle(-45)
-	,stopAngle(225)
-	,angularResolution(.5)
+	,startAngle(-5)
+	,stopAngle(70)
+	,angularResolution(5)
 	,newFrame(false)
 	,invert(false) {
 }
@@ -222,7 +222,7 @@ void ofxSickGrabber::connect() {
 	ofLogVerbose("ofxSickGrabber") << "Logging in.";
 	laser.login();
 	
-	laser.stopMeas(); // unnecessary?
+	//laser.stopMeas(); // unnecessary?
 	
 	scanCfg targetCfg;
 	targetCfg.angleResolution = angularResolution * 1000;
@@ -232,20 +232,24 @@ void ofxSickGrabber::connect() {
 	
 	ofLogVerbose("ofxSickGrabber") << "Setting new scan configuration.";
 	laser.setScanCfg(targetCfg);
+    laser.setScanRange(targetCfg);
 	
 	ofLogVerbose("ofxSickGrabber") << "Updating current scan configuration.";
-	scanCfg curCfg = laser.getScanCfg();
-	
-	scanningFrequency = curCfg.scaningFrequency / 100.;
-	angularResolution = curCfg.angleResolution / 10000.;
-	startAngle = curCfg.startAngle / 10000.;
-	stopAngle = curCfg.stopAngle / 10000.;	
+	scanCfg freqAndRes = laser.getScanCfg();
+	scanCfg range = laser.getScanRange();
+    
+    laser.saveConfig();
+    
+	scanningFrequency = freqAndRes.scaningFrequency / 100.;
+	angularResolution = freqAndRes.angleResolution / 10000.;
+	startAngle = range.startAngle / 10000.;
+	stopAngle = range.stopAngle / 10000.;
 	ofLogVerbose("ofxSickGrabber") << scanningFrequency << "Hz at " << angularResolution << "deg, from " << startAngle << "deg to " << stopAngle << "deg";
 	
-	confirmCfg(curCfg.angleResolution, targetCfg.angleResolution, "angular resolution");
-	confirmCfg(curCfg.scaningFrequency, targetCfg.scaningFrequency, "scanning frequency");
-	confirmCfg(curCfg.startAngle, targetCfg.startAngle, "start angle");
-	confirmCfg(curCfg.stopAngle, targetCfg.stopAngle, "stop angle");
+	confirmCfg(freqAndRes.angleResolution, targetCfg.angleResolution, "angular resolution");
+	confirmCfg(freqAndRes.scaningFrequency, targetCfg.scaningFrequency, "scanning frequency");
+	confirmCfg(range.startAngle, targetCfg.startAngle, "start angle");
+	confirmCfg(range.stopAngle, targetCfg.stopAngle, "stop angle");
 	
 	bool enableSecondReturn = false;
 	scanDataCfg targetDataCfg;
@@ -260,6 +264,8 @@ void ofxSickGrabber::connect() {
 	ofLogVerbose("ofxSickGrabber") << "Setting scan data configuration.";
 	laser.setScanDataCfg(targetDataCfg);
 	
+    laser.startDevice();
+    
 	ofLogVerbose("ofxSickGrabber") << "Start measurments.";
 	laser.startMeas();
 	


### PR DESCRIPTION
...ing reflected in data output. This was done by adding two new functions to LMS1xx.h, setScanRange and getScanRange. In addition, ensured that an LMS5xx could also be used by specifically telling the laser to run in ofxSick class's connect function with startDevice().

Got a 5xx to run the basic example, hooray! I'm hoping this doesn't break the 1xx ability to function, but I only have a 5xx so I can't test this. Blob detection is broken but I'll open up an issue to explain that.

I was examining the message spec for the 5xx and 1xx models and noticed that mLMPsetscancfg actually ignores whatever angle values you give it. Mechanically, the laser never actually modifies the area it scans but it does modify its frequency and resolution so I suppose it makes sense. The spec I found is here: https://dl.dropboxusercontent.com/u/60273224/im0045927.pdf

I assumed this was an oversight and modified the code so that now whatever angle values you provide in the ofxSick constructor are reflected in the laser's data output. 
